### PR TITLE
Fix bug making time infinite in breathless

### DIFF
--- a/Source/ProjectMILA/GameEventManager.cpp
+++ b/Source/ProjectMILA/GameEventManager.cpp
@@ -11,10 +11,12 @@ void UGameEventManager::Tick(float DeltaTime)
 {
 	if (bCountDown && Time <= 0.f)
 	{
-		ASpaceGameStateBase::Instance(GetWorld())->Die(CurrentEvent->DeathReason);
-		bDead = true;
-		bCountDown = false;
-		Time = 0.f;
+		if (ASpaceGameStateBase::Instance(GetWorld())->Die(CurrentEvent->DeathReason))
+		{
+			bDead = true;
+			bCountDown = false;
+			Time = 0.f;
+		}
 	}
 	else if (bCountDown)
 	{

--- a/Source/ProjectMILA/SpaceCharacter.cpp
+++ b/Source/ProjectMILA/SpaceCharacter.cpp
@@ -184,6 +184,26 @@ void ASpaceCharacter::ToggleGravity()
 	}
 }
 
+bool ASpaceCharacter::ToggleOxygen(bool consumeOxygen) const
+{
+	if (EquippedSuit)
+	{
+		ASpaceGameStateBase* state = Cast<ASpaceGameStateBase>(UGameplayStatics::GetGameState(GetWorld()));
+
+		state->SpacestationManager->bReduceLifeTime = consumeOxygen;
+		state->SpacestationManager->LifeTime = state->GameEventManager->GetTime();
+
+		if (consumeOxygen)
+			EquippedSuit->StartConsumingOxygen();
+		else
+			EquippedSuit->StopConsumingOxygen();
+
+		return true;
+	}
+
+	return false;
+}
+
 void ASpaceCharacter::ToggleSpaceSuit(ASpaceSuitActor* spaceSuit)
 {
 	EquippedSuit = spaceSuit;

--- a/Source/ProjectMILA/SpaceCharacter.h
+++ b/Source/ProjectMILA/SpaceCharacter.h
@@ -25,6 +25,7 @@ public:
 	void ReleaseObject();
 	void UnequipObject();
 	void ToggleGravity();
+	bool ToggleOxygen(bool consumeOxygen) const;
 	void ToggleSpaceSuit(ASpaceSuitActor* spaceSuit);
 
 	UFUNCTION(BlueprintCallable, Category = Spacesuit)

--- a/Source/ProjectMILA/SpaceGameStateBase.cpp
+++ b/Source/ProjectMILA/SpaceGameStateBase.cpp
@@ -72,14 +72,17 @@ void ASpaceGameStateBase::ToggleSpaceSuit(bool activate) const
 	}
 }
 
-void ASpaceGameStateBase::Die(EDeathReason reason)
+bool ASpaceGameStateBase::Die(EDeathReason reason)
 {
 	ASpaceCharacter* character = Cast<ASpaceCharacter>(UGameplayStatics::GetPlayerCharacter(GetWorld(), 0));
 
 	if (character)
 	{
 		if (reason == EDeathReason::Choke && character->WearsSpaceSuit() && !character->GetEquippedSuit()->IsConsumingOxygen())
-			character->GetEquippedSuit()->StartConsumingOxygen();
+		{
+			character->ToggleOxygen(true);
+			return false;
+		}
 		else
 		{
 			USpaceGameInstance* gameInstance = static_cast<USpaceGameInstance*>(GetGameInstance());
@@ -104,6 +107,8 @@ void ASpaceGameStateBase::Die(EDeathReason reason)
 			}
 		}
 	}
+
+	return true;
 }
 
 void ASpaceGameStateBase::EndGame()

--- a/Source/ProjectMILA/SpaceGameStateBase.h
+++ b/Source/ProjectMILA/SpaceGameStateBase.h
@@ -32,7 +32,7 @@ public:
 	void ToggleSpaceSuit(bool activate) const;
 
 	UFUNCTION(Exec)
-	void Die(EDeathReason reason);
+	bool Die(EDeathReason reason);
 
 	void EndGame();
 


### PR DESCRIPTION
If the player wears the spacesuit and the spacestation runs out of oxygen when he is inside, the game state machine will be set in dead mode and will stop the timer, so the oxygen never descends.